### PR TITLE
Update acorn to 1.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,10 @@ module.exports = function (options) {
  * @return {Object} The AST of the given src
  */
 module.exports.prototype.parse = function(src, options) {
-  // Stopgap until https://github.com/marijnh/acorn/commit/e37c07248e7ad553b6b4df451c6ba1a935cb379a is released
-  src = src.replace('#!', '//');
+  options = options || {};
+  if (options.allowHashBang == null) {
+    options.allowHashBang = true;
+  }
 
   return acorn.parse(src, options);
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/mrjoelkemp/node-source-walk",
   "dependencies": {
-    "acorn": "~0.10.0"
+    "acorn": "^1.0.3"
   },
   "devDependencies": {
     "mocha": "~2.0.1",


### PR DESCRIPTION
This updates acorn to version 1.x. Since the changes related to hashbangs have been merged, we set that option unless it was explicitly disabled by the caller. Existing tests continue to pass.

Would be awesome if you could pull this in and bump your various `node-detective` implementations if you merge this :smile: 

Thanks for the great modules.