### PR TITLE
Add JSX support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,16 @@
-var acorn = require('acorn');
+var acorn = require('acorn-jsx/inject')(require('acorn'));
+var assign = require('object-assign');
 
 /**
  * @param  {Object} options - Options to configure parser
  * @param  {Boolean} [options.ecmaVersion=5]
  */
 module.exports = function (options) {
-  this.options = options || {};
-
-  this.options.ecmaVersion = this.options.ecmaVersion || 6;
-  this.options.sourceType = this.options.sourceType || 'module';
+  this.options = assign({
+    ecmaVersion: 6,
+    plugins: { jsx: true },
+    sourceType: 'module'
+  }, options);
 
   // We use global state to stop the recursive traversal of the AST
   this.shouldStop = false;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "homepage": "https://github.com/mrjoelkemp/node-source-walk",
   "dependencies": {
-    "acorn": "~2.0.4"
+    "acorn": "~2.0.4",
+    "acorn-jsx": "^2.0.1",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "mocha": "~2.0.1",

--- a/test/test.js
+++ b/test/test.js
@@ -85,3 +85,24 @@ describe('node-source-walk', function() {
     });
   });
 });
+
+describe('node-source-walk', function () {
+  describe('jsx', function () {
+    var spy, walker;
+
+    beforeEach(function () {
+      spy = sinon.spy();
+      walker = new Walker();
+    });
+
+    it('parse', function () {
+      walker.walk('<jsx />', function (node) {
+        if (node.type === 'JSXIdentifier') {
+          spy();
+          assert.equal(node.name, 'jsx');
+        }
+      });
+      assert.equal(spy.callCount, 1);
+    });
+  });
+});


### PR DESCRIPTION
References #12.

This is a PR to add support for parsing code that may contain JSX. It uses a method of injecting `acorn` into `acorn-jsx` so that we don't have to rely on their version of `acorn`.

Comments in PR explaining rationale of changes.